### PR TITLE
Update project.clj dependency versions

### DIFF
--- a/Pages/Page 5_More code changes.md
+++ b/Pages/Page 5_More code changes.md
@@ -13,9 +13,9 @@ We need to write code that will generate HTML. To do this, we will use a library
 Add hiccup by updating the `project.clj` file to look like this:
 
 ```clojure
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [compojure "1.3.1"]
-                 [ring/ring-defaults "0.1.2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [compojure "1.4.0"]
+                 [ring/ring-defaults "0.1.5"]
                  [hiccup "1.0.5"]]
 ```
 

--- a/Pages/Page 6_Push to live.md
+++ b/Pages/Page 6_Push to live.md
@@ -38,14 +38,14 @@ Our new `project.clj` should look like:
   :description "clojure web app for displaying messages"
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [compojure "1.3.1"]
-                 [ring/ring-defaults "0.1.2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [compojure "1.4.0"]
+                 [ring/ring-defaults "0.1.5"]
                  [ring/ring-jetty-adapter "1.3.2"]
                  [hiccup "1.0.5"]
                  [hickory "0.5.4"]
                  [environ "1.0.0"]]
-  :plugins [[lein-ring "0.8.13"]
+  :plugins [[lein-ring "0.9.7"]
             [lein-environ "1.0.0"]]
   :ring {:handler chatter.handler/app
          :init chatter.handler/init
@@ -55,7 +55,7 @@ Our new `project.clj` should look like:
   :profiles
   {:dev
    {:dependencies [[javax.servlet/servlet-api "2.5"]
-                   [ring-mock "0.1.5"]]}
+                   [ring-mock "0.3.0"]]}
    :production
    {:ring
     {:open-browser? false, :stacktraces? false, :auto-reload? false}


### PR DESCRIPTION
Page 5 and Page 6 have listings of the project.clj file which show version numbers that are not current with the version numbers that 'lein new compojure' creates.
